### PR TITLE
BLDKCMF-64: GPLv2 Code in IPOEHealthCheck

### DIFF
--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -859,7 +859,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     udphdr.len = htons(IHC_UDP_HDRLEN + datalen);
 
     // UDP checksum (16 bits)
-    if ((udphdr.check = udp6_checksum(iphdr, udphdr, data, datalen)) == 0)
+    if ((udphdr.check = calculate_udp6_checksum(iphdr, udphdr, data, datalen)) == 0)
     {
         IhcError("[%s %d] unable to generate checksum", __FUNCTION__, __LINE__);
         return IHC_FAILURE;


### PR DESCRIPTION
Reason for change: Modified apis that are match for GPLv2 code

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1