### PR TITLE
SHARMAN-3784:IPOE health check in IPV6 is in idle state on devices loaded with sprint image.

### DIFF
--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -686,14 +686,13 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
     char packet_buffer[IP_MAXPACKET];
     char *buffer_ptr = packet_buffer;
     int checksum_len = 0;
+    int i;
 
     // Add source IPv6 address (128 bits)
     append_to_buffer(&buffer_ptr, &checksum_len, &ipv6_header.ip6_src.s6_addr,sizeof(ipv6_header.ip6_src.s6_addr));
     append_to_buffer(&buffer_ptr, &checksum_len, &ipv6_header.ip6_dst.s6_addr,sizeof(ipv6_header.ip6_dst.s6_addr));
 
     // Add UDP length (32 bits)
-//    uint32_t udp_payload_length = ntohs(udp_header.len);
-//    append_to_buffer(&buffer_ptr, &checksum_len, &udp_payload_length,sizeof(udp_payload_length));
     append_to_buffer(&buffer_ptr, &checksum_len, &udp_header.len,sizeof(udp_header.len));
 
     // Add zero padding (24 bits)
@@ -710,30 +709,21 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
     append_to_buffer(&buffer_ptr, &checksum_len, &udp_header.len, sizeof(udp_header.len));
 
     // Add zeroed checksum field (16 bits)
-//    uint16_t zero_checksum = 0;
-//    append_to_buffer(&buffer_ptr, &checksum_len, &zero_checksum, sizeof(zero_checksum));
     memset(buffer_ptr, 0, 2);
     buffer_ptr += 2;
     checksum_len += 2;
+
     // Add payload data
     append_to_buffer(&buffer_ptr, &checksum_len, payload, payload_len);
 
     // Pad to 16-bit boundary if needed
-/*    if (payload_len % 2 != 0)
-    {
-        *buffer_ptr = 0;
-        buffer_ptr++;
-        checksum_len++;
-    }*/
-    int i ;
     for (i = 0; i < payload_len%2 ; i++ , buffer_ptr++)
     {
         *buffer_ptr = 0;
         buffer_ptr++;
         checksum_len++;
     }	
-IhcInfo ("%s:%d KAVYA checksum_len = [%d]",__FUNCTION__,__LINE__,checksum_len);
-IhcInfo ("%s:%d KAVYA compute_checksum =  [%hu]",__FUNCTION__,__LINE__,compute_checksum((uint16_t *)packet_buffer, checksum_len));
+
     return compute_checksum((uint16_t *)packet_buffer, checksum_len);
 }
 

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -753,6 +753,9 @@ static uint16_t udp6_checksum(struct ip6_hdr iphdr, struct udphdr udphdr, uint8_
         ptr++;
         chksumlen++;
     }
+  IhcInfo ("[%s :%d] buffer  = [%s]",__FUNCTION__, __LINE__,buf);
+  IhcInfo ("[%s :%d] chksumlen  = [%d]",__FUNCTION__, __LINE__,chksumlen);
+    
 IhcInfo ("[%s :%d] checksum = [%hu]",__FUNCTION__, __LINE__, checksum((uint16_t *)buf, chksumlen));
     return checksum((uint16_t *)buf, chksumlen);
 }
@@ -855,9 +858,11 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
         buffer_ptr++;
         checksum_len++;
     }
-    
-    IhcInfo ("[%s :%d] compute_checksum = [%hu]",__FUNCTION__, __LINE__, compute_checksum((uint16_t *)packet_buffer, checksum_len));	    
-    return compute_checksum((uint16_t *)packet_buffer, checksum_len);
+  IhcInfo ("[%s :%d] packet_buffer  = [%s]",__FUNCTION__, __LINE__,packet_buffer);
+  IhcInfo ("[%s :%d] checksum_len  = [%d]",__FUNCTION__, __LINE__,checksum_len);
+    IhcInfo ("[%s :%d] compute_checksum = [%hu]",__FUNCTION__, __LINE__, compute_checksum((uint16_t *)packet_buffer, checksum_len));	   
+   IhcInfo ("[%s :%d] checksum = [%hu]",__FUNCTION__, __LINE__, checksum((uint16_t *)packet_buffer, checksum_len)); 
+    return checksum((uint16_t *)packet_buffer, checksum_len);
 }
 
 /**
@@ -873,7 +878,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
 	    IhcInfo ("[%s :%d] KAVYA ENTER ..",__FUNCTION__, __LINE__);
     int status = 0;
     int datalen = 0;
-    int frame_length = 0;
+    int frame_length = 0;payload
     int bytes = 0;
     struct ip6_hdr iphdr;
     struct udphdr udphdr;
@@ -1015,31 +1020,50 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
 
     // Destination and Source MAC addresses
     memcpy(ether_frame, dst_mac, IHC_MACADDR_LEN);
+    int i = 0;
+    for(i=0; i<IHC_MACADDR_LEN ; i++)
+    {
+        IhcInfo ("[%d] = [%hhu]",i,ether_frame[i]);
+    }
     memcpy(ether_frame + IHC_MACADDR_LEN, src_mac, IHC_MACADDR_LEN);
 
+    for(i=IHC_MACADDR_LEN;i<IHC_MACADDR_LEN+IHC_MACADDR_LEN;i++)
+    {
+	    IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+    }
     // Next is ethernet type code (ETH_P_IPV6 for IPv6).
     // http://www.iana.org/assignments/ethernet-numbers
     ether_frame[12] = ETH_P_IPV6 / 256;
     ether_frame[13] = ETH_P_IPV6 % 256;
-
+IhcInfo ("[12] = [%hhu]",ether_frame[12]);
+IhcInfo ("[13] = [%hhu]",ether_frame[13]);
     // Next is ethernet frame data (IPv6 header + UDP header + UDP data).
 
     // IPv6 header
     memcpy(ether_frame + IHC_ETH_HDRLEN, &iphdr, IHC_IP6_HDRLEN);
-
+for(i=IHC_ETH_HDRLEN ; i< IHC_ETH_HDRLEN+IHC_IP6_HDRLEN ; i++)
+{
+	IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+}
     // UDP header
     memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN, &udphdr, IHC_UDP_HDRLEN);
-
+for(i=IHC_ETH_HDRLEN + IHC_IP6_HDRLEN ; i< IHC_ETH_HDRLEN + IHC_IP6_HDRLEN+IHC_UDP_HDRLEN ; i++)
+{
+	IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+}
     // UDP data
     memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN, data, datalen);
-
-    IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
+for(i=IHC_ETH_HDRLEN + IHC_IP6_HDRLEN+IHC_UDP_HDRLEN ; i< IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN+datalen; i++)
+{
+	IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+}
+    IhcInfo ("[%s :%d] KAVYA  frame_length = [%d] datalen = [%d]",__FUNCTION__, __LINE__,frame_length,datalen);
     IhcInfo ("[%s :%d] KAVYA ether_frame = ",__FUNCTION__, __LINE__);
-    int i;
+/*    int i;
     for(i=0;i<frame_length;i++)
     {
         IhcInfo ("[%hhu]",ether_frame[i]);
-    }
+    }*/
     // Submit request for a raw socket descriptor.
     if ((sockV6 = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL))) < 0)
     {
@@ -1087,8 +1111,18 @@ IhcInfo ("[%s :%d] KAVYA Calling udp6_checksum..\n",__FUNCTION__, __LINE__);
 
     // Destination and Source MAC addresses
     memcpy(ether_frame, dst_mac, IHC_MACADDR_LEN);
+//    int i = 0;
+    for(i=0; i<IHC_MACADDR_LEN ; i++)
+    {
+        IhcInfo ("[%d] = [%hhu]",i,ether_frame[i]);
+    }
+    
     memcpy(ether_frame + IHC_MACADDR_LEN, src_mac, IHC_MACADDR_LEN);
-
+    for(i=IHC_MACADDR_LEN;i<IHC_MACADDR_LEN+IHC_MACADDR_LEN;i++)
+    {
+            IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+    }
+ 
     // Next is ethernet type code (ETH_P_IPV6 for IPv6).
     // http://www.iana.org/assignments/ethernet-numbers
     ether_frame[12] = ETH_P_IPV6 / 256;
@@ -1098,19 +1132,29 @@ IhcInfo ("[%s :%d] KAVYA Calling udp6_checksum..\n",__FUNCTION__, __LINE__);
 
     // IPv6 header
     memcpy(ether_frame + IHC_ETH_HDRLEN, &iphdr, IHC_IP6_HDRLEN);
-
+for(i=IHC_ETH_HDRLEN ; i< IHC_ETH_HDRLEN+IHC_IP6_HDRLEN ; i++)
+{
+        IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+}
     // UDP header
     memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN, &udphdr, IHC_UDP_HDRLEN);
-
+for(i=IHC_ETH_HDRLEN + IHC_IP6_HDRLEN ; i< IHC_ETH_HDRLEN + IHC_IP6_HDRLEN+IHC_UDP_HDRLEN ; i++)
+{
+        IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+}
     // UDP data
     memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN, data, datalen);
+for(i=IHC_ETH_HDRLEN + IHC_IP6_HDRLEN+IHC_UDP_HDRLEN ; i< IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN+datalen; i++)
+{
+        IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
+}
 
     IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
     IhcInfo ("[%s :%d] KAVYA ether_frame = ",__FUNCTION__, __LINE__);
-    for(i=0;i<frame_length;i++)
+/*    for(i=0;i<frame_length;i++)
     {
         IhcInfo ("[%hhu]",ether_frame[i]);
-    }
+    }*/
     // Submit request for a raw socket descriptor.
     if ((sockV6 = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL))) < 0)
     {

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -924,7 +924,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
 
     IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
     int i=0;
-    for(i=0,i<IHC_MAX_STRING_LENGTH;i++)
+    for(i=0;i<IHC_MAX_STRING_LENGTH;i++)
     {
         IhcInfo ("[%s :%d] KAVYA ether_frame[%d] = %hhu\n",__FUNCTION__, __LINE__,i, ether_frame[i]);
     }

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -753,7 +753,7 @@ static uint16_t udp6_checksum(struct ip6_hdr iphdr, struct udphdr udphdr, uint8_
         ptr++;
         chksumlen++;
     }
-
+IhcInfo ("[%s :%d] checksum = [%hu]",__FUNCTION__, __LINE__, checksum((uint16_t *)buf, chksumlen));
     return checksum((uint16_t *)buf, chksumlen);
 }
 

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -1034,8 +1034,8 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN, data, datalen);
 
     IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
-    int i=0;
     IhcInfo ("[%s :%d] KAVYA ether_frame = ",__FUNCTION__, __LINE__);
+    int i;
     for(i=0;i<frame_length;i++)
     {
         IhcInfo ("[%hhu]",ether_frame[i]);
@@ -1106,7 +1106,6 @@ IhcInfo ("[%s :%d] KAVYA Calling udp6_checksum..\n",__FUNCTION__, __LINE__);
     memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN, data, datalen);
 
     IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
-    int i=0;
     IhcInfo ("[%s :%d] KAVYA ether_frame = ",__FUNCTION__, __LINE__);
     for(i=0;i<frame_length;i++)
     {

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -1058,7 +1058,6 @@ for(i=IHC_ETH_HDRLEN + IHC_IP6_HDRLEN+IHC_UDP_HDRLEN ; i< IHC_ETH_HDRLEN + IHC_I
 	IhcInfo ("[%d] = [%hhu]",ether_frame[i]);
 }
     IhcInfo ("[%s :%d] KAVYA  frame_length = [%d] datalen = [%d]",__FUNCTION__, __LINE__,frame_length,datalen);
-    IhcInfo ("[%s :%d] KAVYA ether_frame = ",__FUNCTION__, __LINE__);
 /*    int i;
     for(i=0;i<frame_length;i++)
     {
@@ -1127,7 +1126,8 @@ IhcInfo ("[%s :%d] KAVYA Calling udp6_checksum..\n",__FUNCTION__, __LINE__);
     // http://www.iana.org/assignments/ethernet-numbers
     ether_frame[12] = ETH_P_IPV6 / 256;
     ether_frame[13] = ETH_P_IPV6 % 256;
-
+IhcInfo ("[12] = [%hhu]",ether_frame[12]);
+IhcInfo ("[13] = [%hhu]",ether_frame[13]);
     // Next is ethernet frame data (IPv6 header + UDP header + UDP data).
 
     // IPv6 header
@@ -1150,7 +1150,6 @@ for(i=IHC_ETH_HDRLEN + IHC_IP6_HDRLEN+IHC_UDP_HDRLEN ; i< IHC_ETH_HDRLEN + IHC_I
 }
 
     IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
-    IhcInfo ("[%s :%d] KAVYA ether_frame = ",__FUNCTION__, __LINE__);
 /*    for(i=0;i<frame_length;i++)
     {
         IhcInfo ("[%hhu]",ether_frame[i]);

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -878,7 +878,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
 	    IhcInfo ("[%s :%d] KAVYA ENTER ..",__FUNCTION__, __LINE__);
     int status = 0;
     int datalen = 0;
-    int frame_length = 0;payload
+    int frame_length = 0;
     int bytes = 0;
     struct ip6_hdr iphdr;
     struct udphdr udphdr;

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -621,52 +621,53 @@ static uint16_t csum(uint16_t *buf, int nwords)
     sum += (sum >> CSUM_16_BIT_SHIFT);
     return (uint16_t)(~sum);
 }
-
 // Note that the internet checksum does not preclude collisions.
 /**
  * @brief Data checksum calculations
- * 
- * @param data Paylaod data
+ *
+ * @param addr Paylaod data
  * @param len payload length
  * @return uint16_t calculated checksum
  */
-static uint16_t compute_checksum(uint16_t *data, int len)
+
+static uint16_t checksum(uint16_t *addr, int len)
 {
-    if (data == NULL || len <= 0) {
+    int count = len;
+    register uint32_t sum = 0;
+    uint16_t answer = 0;
+
+    if (addr == NULL)
+    {
         IhcError("[%s: %d] Invalid args..", __FUNCTION__, __LINE__);
         return IHC_FAILURE;
-    }    
-    const uint8_t *bytes = (const uint8_t *)data;
-    uint32_t sum = 0;
-
-    // Sum 16-bit words
-    while (len > 1) {
-        uint16_t word = ((uint16_t)bytes[0] << 8) | bytes[1];
-        sum += word;
-        bytes += 2;
-        len -= 2;
     }
 
-    // Add left-over byte, if any (pad with zero)
-    if (len > 0) {
-        uint16_t word = ((uint16_t)bytes[0]) << 8;
-        sum += word;
+    // Sum up 2-byte values until none or only one byte left.
+    while (count > 1)
+    {
+        sum += *(addr++);
+        count -= 2;
     }
 
+    // Add left-over byte, if any.
+    if (count > 0)
+    {
+        sum += *(uint8_t *)addr;
+    }
+
+    // Implementation based on RFC1071.
     // Fold 32-bit sum to 16 bits
     while (sum >> 16)
-        sum = (sum & 0xFFFF) + (sum >> 16);
+    {
+        sum = (sum & CSUM_16_BIT_MASK) + (sum >> 16);
+    }
 
-    // One's complement
-    return (uint16_t)(~sum);
+    // Checksum is one's compliment of sum.
+    answer = ~sum;
+
+    return (answer);
 }
 
-static void append_to_buffer(char **buf_ptr, int *total_len, const void *src, size_t size)
-{
-    memcpy(*buf_ptr, src, size);
-    *buf_ptr += size;
-    *total_len += size;
-}
 
 /**
  * @brief IPV6 UDP header checksum calculation functions
@@ -677,55 +678,86 @@ static void append_to_buffer(char **buf_ptr, int *total_len, const void *src, si
  * @param payloadlen Payload length
  * @return uint16_t return checksum
  */
-static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphdr udp_header, uint8_t *payload, int payload_len)
+
+static uint16_t udp6_checksum(struct ip6_hdr iphdr, struct udphdr udphdr, uint8_t *payload, int payloadlen)
 {
+    char buf[IP_MAXPACKET];
+    char *ptr;
+    int chksumlen = 0;
+    int i;
+
     if (payload == NULL)
     {
-	IhcError("[%s %d] Invalid args...", __FUNCTION__, __LINE__);
+        IhcError("[%s %d] Invalid args...", __FUNCTION__, __LINE__);
         return 0;
     }
-    char packet_buffer[IP_MAXPACKET];
-    char *buffer_ptr = packet_buffer;
-    int checksum_len = 0;
 
-    // Add source IPv6 address (128 bits)
-    append_to_buffer(&buffer_ptr, &checksum_len, &ipv6_header.ip6_src.s6_addr,sizeof(ipv6_header.ip6_src.s6_addr));
-    append_to_buffer(&buffer_ptr, &checksum_len, &ipv6_header.ip6_dst.s6_addr,sizeof(ipv6_header.ip6_dst.s6_addr));
+    ptr = &buf[0]; // ptr points to beginning of buffer buf
 
-    // Add UDP length (32 bits)
-    uint32_t udp_payload_length = ntohs(udp_header.len);
-    append_to_buffer(&buffer_ptr, &checksum_len, &udp_payload_length,sizeof(udp_payload_length));
+    // Copy source IP address into buf (128 bits)
+    memcpy(ptr, &iphdr.ip6_src.s6_addr, sizeof(iphdr.ip6_src.s6_addr));
+    ptr += sizeof(iphdr.ip6_src.s6_addr);
+    chksumlen += sizeof(iphdr.ip6_src.s6_addr);
 
-    // Add zero padding (24 bits)
-    memset(buffer_ptr, 0, 3);
-    buffer_ptr += 3;
-    checksum_len += 3;
 
-    // Add next header field (8 bits)
-    append_to_buffer(&buffer_ptr, &checksum_len, &ipv6_header.ip6_nxt, sizeof(ipv6_header.ip6_nxt));
+    // Copy destination IP address into buf (128 bits)
+    memcpy(ptr, &iphdr.ip6_dst.s6_addr, sizeof(iphdr.ip6_dst.s6_addr));
+    ptr += sizeof(iphdr.ip6_dst.s6_addr);
+    chksumlen += sizeof(iphdr.ip6_dst.s6_addr);
 
-    // Add UDP header
-    append_to_buffer(&buffer_ptr, &checksum_len, &udp_header.source, sizeof(udp_header.source));
-    append_to_buffer(&buffer_ptr, &checksum_len, &udp_header.dest, sizeof(udp_header.dest));
-    append_to_buffer(&buffer_ptr, &checksum_len, &udp_header.len, sizeof(udp_header.len));
+    // Copy UDP length into buf (32 bits)
+    memcpy(ptr, &udphdr.len, sizeof(udphdr.len));
+    ptr += sizeof(udphdr.len);
+    chksumlen += sizeof(udphdr.len);
 
-    // Add zeroed checksum field (16 bits)
-    uint16_t zero_checksum = 0;
-    append_to_buffer(&buffer_ptr, &checksum_len, &zero_checksum, sizeof(zero_checksum));
+    // Copy zero field to buf (24 bits)
+    memset(ptr, 0, 3);
+    ptr += 3;
+    chksumlen += 3;
 
-    // Add payload data
-    append_to_buffer(&buffer_ptr, &checksum_len, payload, payload_len);
+    // Copy next header field to buf (8 bits)
+    memcpy(ptr, &iphdr.ip6_nxt, sizeof(iphdr.ip6_nxt));
+    ptr += sizeof(iphdr.ip6_nxt);
+    chksumlen += sizeof(iphdr.ip6_nxt);
 
-    // Pad to 16-bit boundary if needed
-    if (payload_len % 2 != 0)
+    // Copy UDP source port to buf (16 bits)
+    memcpy(ptr, &udphdr.source, sizeof(udphdr.source));
+    ptr += sizeof(udphdr.source);
+    chksumlen += sizeof(udphdr.source);
+
+    // Copy UDP destination port to buf (16 bits)
+    memcpy(ptr, &udphdr.dest, sizeof(udphdr.dest));
+    ptr += sizeof(udphdr.dest);
+    chksumlen += sizeof(udphdr.dest);
+
+    // Copy UDP length again to buf (16 bits)
+    memcpy(ptr, &udphdr.len, sizeof(udphdr.len));
+    ptr += sizeof(udphdr.len);
+    chksumlen += sizeof(udphdr.len);
+
+    // Copy UDP checksum to buf (16 bits)
+    // Zero, since we don't know it yet
+    memset(ptr, 0, 2);
+    ptr += 2;
+    chksumlen += 2;
+
+    // Copy payload to buf
+    memcpy(ptr, payload, payloadlen);
+    ptr += payloadlen;
+    chksumlen += payloadlen;
+
+    // Pad to the next 16-bit boundary
+    for (i = 0; i < payloadlen % 2; i++, ptr++)
     {
-        *buffer_ptr = 0;
-        buffer_ptr++;
-        checksum_len++;
+        *ptr = 0;
+        ptr++;
+        chksumlen++;
     }
 
-    return compute_checksum((uint16_t *)packet_buffer, checksum_len);
+    return checksum((uint16_t *)buf, chksumlen);
 }
+
+
 /**
  * @brief Function to send IPV6 echo packets
  * 
@@ -859,7 +891,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     udphdr.len = htons(IHC_UDP_HDRLEN + datalen);
 
     // UDP checksum (16 bits)
-    if ((udphdr.check = calculate_udp6_checksum(iphdr, udphdr, data, datalen)) == 0)
+    if ((udphdr.check = udp6_checksum(iphdr, udphdr, data, datalen)) == 0)
     {
         IhcError("[%s %d] unable to generate checksum", __FUNCTION__, __LINE__);
         return IHC_FAILURE;

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -692,8 +692,9 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
     append_to_buffer(&buffer_ptr, &checksum_len, &ipv6_header.ip6_dst.s6_addr,sizeof(ipv6_header.ip6_dst.s6_addr));
 
     // Add UDP length (32 bits)
-    uint32_t udp_payload_length = ntohs(udp_header.len);
-    append_to_buffer(&buffer_ptr, &checksum_len, &udp_payload_length,sizeof(udp_payload_length));
+//    uint32_t udp_payload_length = ntohs(udp_header.len);
+//    append_to_buffer(&buffer_ptr, &checksum_len, &udp_payload_length,sizeof(udp_payload_length));
+    append_to_buffer(&buffer_ptr, &checksum_len, &udp_header.len,sizeof(udp_header.len));
 
     // Add zero padding (24 bits)
     memset(buffer_ptr, 0, 3);
@@ -709,20 +710,30 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
     append_to_buffer(&buffer_ptr, &checksum_len, &udp_header.len, sizeof(udp_header.len));
 
     // Add zeroed checksum field (16 bits)
-    uint16_t zero_checksum = 0;
-    append_to_buffer(&buffer_ptr, &checksum_len, &zero_checksum, sizeof(zero_checksum));
-
+//    uint16_t zero_checksum = 0;
+//    append_to_buffer(&buffer_ptr, &checksum_len, &zero_checksum, sizeof(zero_checksum));
+    memset(buffer_ptr, 0, 2);
+    buffer_ptr += 2;
+    checksum_len += 2;
     // Add payload data
     append_to_buffer(&buffer_ptr, &checksum_len, payload, payload_len);
 
     // Pad to 16-bit boundary if needed
-    if (payload_len % 2 != 0)
+/*    if (payload_len % 2 != 0)
     {
         *buffer_ptr = 0;
         buffer_ptr++;
         checksum_len++;
-    }
-
+    }*/
+    int i ;
+    for (i = 0; i < payload_len%2 ; i++ , buffer_ptr++)
+    {
+        *buffer_ptr = 0;
+        buffer_ptr++;
+        checksum_len++;
+    }	
+IhcInfo ("%s:%d KAVYA checksum_len = [%d]",__FUNCTION__,__LINE__,checksum_len);
+IhcInfo ("%s:%d KAVYA compute_checksum =  [%hu]",__FUNCTION__,__LINE__,compute_checksum((uint16_t *)packet_buffer, checksum_len));
     return compute_checksum((uint16_t *)packet_buffer, checksum_len);
 }
 

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -629,7 +629,7 @@ static uint16_t csum(uint16_t *buf, int nwords)
  * @param len payload length
  * @return uint16_t calculated checksum
  */
-/*
+
 static uint16_t checksum(uint16_t *addr, int len)
 {
     int count = len;
@@ -667,7 +667,7 @@ static uint16_t checksum(uint16_t *addr, int len)
 
     return (answer);
 }
-*/
+
 
 /**
  * @brief IPV6 UDP header checksum calculation functions
@@ -678,7 +678,7 @@ static uint16_t checksum(uint16_t *addr, int len)
  * @param payloadlen Payload length
  * @return uint16_t return checksum
  */
-/*
+
 static uint16_t udp6_checksum(struct ip6_hdr iphdr, struct udphdr udphdr, uint8_t *payload, int payloadlen)
 {
     char buf[IP_MAXPACKET];
@@ -756,7 +756,7 @@ static uint16_t udp6_checksum(struct ip6_hdr iphdr, struct udphdr udphdr, uint8_
 
     return checksum((uint16_t *)buf, chksumlen);
 }
-*/
+
 /**
  * @brief Data checksum calculations
  *
@@ -870,6 +870,7 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
 
 static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
 {
+	    IhcInfo ("[%s :%d] KAVYA ENTER ..",__FUNCTION__, __LINE__);
     int status = 0;
     int datalen = 0;
     int frame_length = 0;
@@ -894,6 +895,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
 
     if (interface == NULL || MACaddress == NULL)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("[%s:%d] Invalid args...", __FUNCTION__, __LINE__);
         return IHC_FAILURE;
     }
@@ -901,6 +903,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     // Submit request for a socket descriptor to look up interface.
     if ((sockV6 = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL))) < 0)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("[%s:%d] socket() failed to get socket descriptor for using ioctl() : %s", __FUNCTION__, __LINE__, strerror(errno));
         return IHC_FAILURE;
     }
@@ -910,6 +913,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", interface);
     if (ioctl(sockV6, SIOCGIFHWADDR, &ifr) < 0)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("ioctl() failed to get source MAC address : %s", strerror(errno));
         close(sockV6);
         return IHC_FAILURE;
@@ -924,6 +928,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     memset(&device, 0, sizeof(device));
     if ((device.sll_ifindex = if_nametoindex(interface)) == 0)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("if_nametoindex() failed to obtain interface index : %s", strerror(errno));
         return IHC_FAILURE;
     }
@@ -939,6 +944,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     IhcInfo ("[%s :%d] BNG MAC %s",__FUNCTION__, __LINE__, MACaddress);
     if ((ret = ihc_get_ipv6_global_address(globalAddress, sizeof(globalAddress))) != IHC_SUCCESS)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("ihc_get_ipv6_global_address failed : %d ", ret);
         return IHC_FAILURE;
     }
@@ -971,6 +977,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     // Source IPv6 address (128 bits)
     if ((status = inet_pton(AF_INET6, src_ip, &(iphdr.ip6_src))) != 1)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("inet_pton() failed.\nError message: %s", strerror(status));
         return IHC_FAILURE;
     }
@@ -978,6 +985,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     // Destination IPv6 address (128 bits)
     if ((status = inet_pton(AF_INET6, src_ip, &(iphdr.ip6_dst))) != 1)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("inet_pton() failed.Error message: %s", strerror(status));
         return IHC_FAILURE;
     }
@@ -993,7 +1001,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     udphdr.len = htons(IHC_UDP_HDRLEN + datalen);
 
     // UDP checksum (16 bits)
-    //if ((udphdr.check = udp6_checksum(iphdr, udphdr, data, datalen)) == 0)
+    IhcInfo ("[%s :%d] KAVYA Calling calculate_udp6_checksum ..",__FUNCTION__, __LINE__);
     if ((udphdr.check = calculate_udp6_checksum(iphdr, udphdr, data, datalen)) == 0)
     {
         IhcError("[%s %d] unable to generate checksum", __FUNCTION__, __LINE__);
@@ -1035,6 +1043,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     // Submit request for a raw socket descriptor.
     if ((sockV6 = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL))) < 0)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("socket() failed : %s", strerror(errno));
         return IHC_FAILURE;
     }
@@ -1042,6 +1051,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     /* setting socket option to use MARK value(Priority 7 - high priority queue) */
     if (setsockopt(sockV6, SOL_SOCKET, SO_MARK, &packet_priority, sizeof(packet_priority)) < 0)
     {
+	    IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("socket marking failed : %s", strerror(errno));
         close(sockV6);
         return IHC_FAILURE;
@@ -1049,6 +1059,7 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     // Send ethernet frame to socket.
     if ((bytes = sendto(sockV6, ether_frame, frame_length, 0, (struct sockaddr *)&device, sizeof(device))) <= 0)
     {
+	 IhcInfo ("[%s :%d] KAVYA ..",__FUNCTION__, __LINE__);
         IhcError("sendto() failed : %s", strerror(errno));
         close(sockV6);
         return IHC_FAILURE;
@@ -1062,6 +1073,78 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     // Close V6 socket descriptor.
     close(sockV6);
 
+IhcInfo ("[%s :%d] KAVYA Calling udp6_checksum..\n",__FUNCTION__, __LINE__);
+    if ((udphdr.check = udp6_checksum(iphdr, udphdr, data, datalen)) == 0)
+    {
+        IhcError("[%s %d] unable to generate checksum", __FUNCTION__, __LINE__);
+        return IHC_FAILURE;
+    }
+
+    // Fill out ethernet frame header.
+
+    // Ethernet frame length = ethernet header (MAC + MAC + ethernet type) + ethernet data (IP header + UDP header + UDP data)
+    frame_length = IHC_MACADDR_LEN + IHC_MACADDR_LEN + IHC_ETHTYPE_LEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN + datalen;
+
+    // Destination and Source MAC addresses
+    memcpy(ether_frame, dst_mac, IHC_MACADDR_LEN);
+    memcpy(ether_frame + IHC_MACADDR_LEN, src_mac, IHC_MACADDR_LEN);
+
+    // Next is ethernet type code (ETH_P_IPV6 for IPv6).
+    // http://www.iana.org/assignments/ethernet-numbers
+    ether_frame[12] = ETH_P_IPV6 / 256;
+    ether_frame[13] = ETH_P_IPV6 % 256;
+
+    // Next is ethernet frame data (IPv6 header + UDP header + UDP data).
+
+    // IPv6 header
+    memcpy(ether_frame + IHC_ETH_HDRLEN, &iphdr, IHC_IP6_HDRLEN);
+
+    // UDP header
+    memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN, &udphdr, IHC_UDP_HDRLEN);
+
+    // UDP data
+    memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN, data, datalen);
+
+    IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
+    int i=0;
+    IhcInfo ("[%s :%d] KAVYA ether_frame = ",__FUNCTION__, __LINE__);
+    for(i=0;i<frame_length;i++)
+    {
+        IhcInfo ("[%hhu]",ether_frame[i]);
+    }
+    // Submit request for a raw socket descriptor.
+    if ((sockV6 = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL))) < 0)
+    {
+	    IhcInfo ("[%s :%d] KAVYA ..\n",__FUNCTION__, __LINE__);
+        IhcError("socket() failed : %s", strerror(errno));
+        return IHC_FAILURE;
+    }
+
+    /* setting socket option to use MARK value(Priority 7 - high priority queue) */
+    if (setsockopt(sockV6, SOL_SOCKET, SO_MARK, &packet_priority, sizeof(packet_priority)) < 0)
+    {
+	    IhcInfo ("[%s :%d] KAVYA ..\n",__FUNCTION__, __LINE__);
+        IhcError("socket marking failed : %s", strerror(errno));
+        close(sockV6);
+        return IHC_FAILURE;
+    }
+    // Send ethernet frame to socket.
+    if ((bytes = sendto(sockV6, ether_frame, frame_length, 0, (struct sockaddr *)&device, sizeof(device))) <= 0)
+    {
+	    IhcInfo ("[%s :%d] KAVYA ..\n",__FUNCTION__, __LINE__);
+        IhcError("sendto() failed : %s", strerror(errno));
+        close(sockV6);
+        return IHC_FAILURE;
+    }
+    else
+    {
+        IhcInfo("Echo packets V6 TX [%u -> %u]", g_echo_V6_failure_count, g_echo_V6_failure_count + 1);
+    IhcInfo ("[%s :%d] KAVYA g_echo_V6_failure_count = [%d]\n",__FUNCTION__, __LINE__,g_echo_V6_failure_count);
+    }
+    // Close V6 socket descriptor.
+    close(sockV6);
+
+    IhcInfo ("[%s :%d] KAVYA Done ..\n",__FUNCTION__, __LINE__);	    
     return IHC_SUCCESS;
 }
 

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -636,6 +636,7 @@ static uint16_t compute_checksum(uint16_t *data, int len)
         return IHC_FAILURE;
     }
     register uint32_t sum = 0;
+    uint16_t answer = 0;
 
     // Sum up 2-byte values until none or only one byte left.
     while (len > 1) {
@@ -655,7 +656,8 @@ static uint16_t compute_checksum(uint16_t *data, int len)
     }
 
     //Checksum is one's complement of sum.
-    return (uint16_t)(~sum);
+    answer = ~sum;
+    return (answer);
 }
 
 static void append_to_buffer(char **buf_ptr, int *total_len, const void *src, size_t size)

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -622,9 +622,9 @@ static uint16_t csum(uint16_t *buf, int nwords)
     return (uint16_t)(~sum);
 }
 
+// Note that the internet checksum does not preclude collisions.
 /**
  * @brief Data checksum calculations
- *
  * @param data Paylaod data
  * @param len payload length
  * @return uint16_t calculated checksum
@@ -697,6 +697,7 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
     memset(buffer_ptr, 0, 3);
     buffer_ptr += 3;
     checksum_len += 3;
+
     // Add next header field (8 bits)
     append_to_buffer(&buffer_ptr, &checksum_len, &ipv6_header.ip6_nxt, sizeof(ipv6_header.ip6_nxt));
 
@@ -720,7 +721,7 @@ static uint16_t calculate_udp6_checksum(struct ip6_hdr ipv6_header, struct udphd
         checksum_len++;
     }
 
-    return  compute_checksum((uint16_t *)packet_buffer, checksum_len);
+    return compute_checksum((uint16_t *)packet_buffer, checksum_len);
 }
 
 /**

--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -922,6 +922,12 @@ static int ihc_sendV6EchoPackets(char *interface, char *MACaddress)
     // UDP data
     memcpy(ether_frame + IHC_ETH_HDRLEN + IHC_IP6_HDRLEN + IHC_UDP_HDRLEN, data, datalen);
 
+    IhcInfo ("[%s :%d] KAVYA  frame_length = [%d]\n",__FUNCTION__, __LINE__,frame_length);
+    int i=0;
+    for(i=0,i<IHC_MAX_STRING_LENGTH;i++)
+    {
+        IhcInfo ("[%s :%d] KAVYA ether_frame[%d] = %hhu\n",__FUNCTION__, __LINE__,i, ether_frame[i]);
+    }
     // Submit request for a raw socket descriptor.
     if ((sockV6 = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL))) < 0)
     {


### PR DESCRIPTION
SHARMAN-3784:IPOE health check in IPV6 is in idle state on devices loaded with sprint image.

Reason for change: Changes part of BLDKCMF-64 caused issue. Handled checksum calculation. 

Test Procedure:
Updated in Jira.

Risks: none
Priority: P0